### PR TITLE
Allows driver to select alsa index automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ dkms.conf
 
 # custom stuff
 .vscode/
+install.sh


### PR DESCRIPTION
Using sound/initval.h 's SNDRV_DEFAULT_IDX and SNDRV_CARDS we can allow the driver to automatically choose its alsa index without the need to use module parameters. 