### PR TITLE
Remove unnecessary wait_prepare and wait_finish callbacks which prevent compilation on Linux kernel 7

### DIFF
--- a/gvusb2-v4l2.c
+++ b/gvusb2-v4l2.c
@@ -200,8 +200,6 @@ static const struct vb2_ops gvusb2_vb2_ops = {
 	.buf_queue       = gvusb2_vb2_buf_queue,
 	.start_streaming = gvusb2_vb2_start_streaming,
 	.stop_streaming  = gvusb2_vb2_stop_streaming,
-	.wait_prepare    = vb2_ops_wait_prepare,
-	.wait_finish     = vb2_ops_wait_finish,
 };
 
 int gvusb2_vb2_setup(struct gvusb2_vid *dev)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,10 @@
+# Unload drivers if they are already loaded
+grep -q "gvusb2_video" /proc/modules && sudo rmmod -f gvusb2_video
+grep -q "gvusb2_sound" /proc/modules && sudo rmmod -f gvusb2_sound
+make clean && make && \
+    sudo mkdir -p /lib/modules/$(uname -r)/kernel/drivers/media/usb/gvusb2/ && \
+    zstd *.ko && \
+    sudo mv -vt /lib/modules/$(uname -r)/kernel/drivers/media/usb/gvusb2/ *.ko.zst && \
+    sudo depmod $(uname -r) && \
+    sudo modprobe -v gvusb2-video && \
+    sudo modprobe -v gvusb2-sound


### PR DESCRIPTION
These callbacks were deprecated and removed in kernel 7, they can be deleted with no issue whatsoever to allow the driver to compile again. Thanks :)